### PR TITLE
bug solved - empty pass is blocked

### DIFF
--- a/En-n-DE-curl-key.go
+++ b/En-n-DE-curl-key.go
@@ -108,6 +108,12 @@ func handlerEcnrypt(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// return error for empty pass
+	if len(encryptRequest.Pass) == 0 {
+		fmt.Fprintf(w, "Invalid (empty) Pass value. Please enter the Pass")
+		return
+	}
+
 	// sends the created var for encryption. As a result - returned the structure "EncryptedResponse" (hash/time),
 	// which is filled
 	encryptedResponse, err := encryptData(encryptRequest)
@@ -216,7 +222,7 @@ func createKeys(inPass string) (key, iv string) {
 
 	// password or passphrase
 	pass := inPass
-	fmt.Println("CrK --- key: ", pass)
+	// fmt.Println("CrK --- key: ", pass)
 
 	return pass + keyTemplate[len(pass):], pass + ivTemplate[len(pass):]
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Solutions:
 2. reserved salt for the future
 3. cleaning
 
-Bugs:
+Bugs solved:
 1. if pass is empty - no pass check on decrypt operation (even 'salt=555' works)
 
 TBD:


### PR DESCRIPTION
Hey @wildneuro. Please approve.

Now the empty 'pass' causes an error.